### PR TITLE
fixed url redirection after adding a problem statement

### DIFF
--- a/cse_hub/homepage/templates/homepage/homepage.html
+++ b/cse_hub/homepage/templates/homepage/homepage.html
@@ -2,5 +2,14 @@
 
 
 {% block content %}
+	{% if messages %}
+		{% for message in messages %}
+			<div class="alert alert-{{ message.tags }} alert-dismissible" role="alert">
+			<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+				{{message}}
+			</div>
+		{% endfor %}
+	{% endif %}
+
 	Working With Bootstrap on homepage
 {% endblock content %}

--- a/cse_hub/problems/templates/problems/add_submission.html
+++ b/cse_hub/problems/templates/problems/add_submission.html
@@ -7,6 +7,7 @@
 	{% if messages %}
 		{% for message in messages %}
 			<div class="alert alert-{{ message.tags }} alert-dismissible" role="alert">
+			<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
 				{{message}}
 			</div>
 			<br>

--- a/cse_hub/problems/templates/problems/add_testcase.html
+++ b/cse_hub/problems/templates/problems/add_testcase.html
@@ -7,6 +7,7 @@
 	{% if messages %}
 		{% for message in messages %}
 			<div class="alert alert-{{ message.tags }} alert-dismissible" role="alert">
+			<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
 				{{message}}
 			</div>
 		{% endfor %}

--- a/cse_hub/problems/templates/problems/display_a_problem.html
+++ b/cse_hub/problems/templates/problems/display_a_problem.html
@@ -2,6 +2,15 @@
 
 {% block content %}
 
+	{% if messages %}
+		{% for message in messages %}
+			<div class="alert alert-{{ message.tags }} alert-dismissible" role="alert">
+			<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+				{{message}}
+			</div>
+		{% endfor %}
+	{% endif %}
+
 	<h2>{{ problem.quesCode }}</h2>
 	<hr>
 	<strong>Problem Description :</strong> <br><br> <div class="pl-3">{{ problem.description|linebreaks }}</div>

--- a/cse_hub/problems/templates/problems/display_a_submission.html
+++ b/cse_hub/problems/templates/problems/display_a_submission.html
@@ -1,6 +1,16 @@
 {% extends 'homepage/index.html' %}
 
 {% block content %}
+
+	{% if messages %}
+		{% for message in messages %}
+			<div class="alert alert-{{ message.tags }} alert-dismissible" role="alert">
+			<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+				{{message}}
+			</div>
+		{% endfor %}
+	{% endif %}
+	
 	<strong>Problem: </strong><a href="{% url 'display-problem' solution.problem_code.id %}" class="btn btn-outline-success btn-sm">{{solution.problem_code}}</a>
 	<a href="{% url 'download-submission' solution.id %}" class="float-right btn btn-sm btn-primary">Download</a>
 

--- a/cse_hub/problems/templates/problems/display_problems.html
+++ b/cse_hub/problems/templates/problems/display_problems.html
@@ -1,9 +1,11 @@
 {% extends 'homepage/index.html' %}
 
-{% block content %}
 	{% if messages %}
 		{% for message in messages %}
-			{{message}} <br>
+			<div class="alert alert-{{ message.tags }} alert-dismissible" role="alert">
+			<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+				{{message}}
+			</div>
 		{% endfor %}
 	{% endif %}
 

--- a/cse_hub/problems/templates/problems/display_submissions.html
+++ b/cse_hub/problems/templates/problems/display_submissions.html
@@ -3,6 +3,15 @@
 
 {% block content %}
 
+	{% if messages %}
+		{% for message in messages %}
+			<div class="alert alert-{{ message.tags }} alert-dismissible" role="alert">
+			<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+				{{message}}
+			</div>
+		{% endfor %}
+	{% endif %}
+
 	<div class="card" style="width: 35rem;">
 		<ul class="list-group list-group-flush">
 			{% for code in codes %}

--- a/cse_hub/problems/views.py
+++ b/cse_hub/problems/views.py
@@ -1,4 +1,5 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.urls import reverse
 from .forms import ProblemForm, TestCaseForm, SubmitSolutionForm
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -128,6 +129,7 @@ def add_problem(request):
 			form.author = request.user
 			form.save()
 			messages.success(request, 'Added problem statement')
+			return redirect(reverse('add-testcase'))
 		else:
 			# print on backend terminal, for debugging purpose
 			print(f'\n Error while adding problem:\n{form.errors.as_data()} \n')

--- a/cse_hub/users/templates/users/profile.html
+++ b/cse_hub/users/templates/users/profile.html
@@ -2,6 +2,15 @@
 {% load mathfilters %}
 
 {% block content-unindent %}
+	{% if messages %}
+		{% for message in messages %}
+			<div class="alert alert-{{ message.tags }} alert-dismissible" role="alert">
+			<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+				{{message}}
+			</div>
+		{% endfor %}
+	{% endif %}
+
 	<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 		<script type="text/javascript">
 			{% if user.profile.problems_TLE or user.profile.problems_solved or user.profile.problems_WA %}

--- a/cse_hub/users/templates/users/profile_edit.html
+++ b/cse_hub/users/templates/users/profile_edit.html
@@ -3,7 +3,19 @@
 {% load crispy_forms_tags %}
 
 {% block content %}
-	Editing profile page of {{ request.user.username }}, More functionalities to be added
+	{% if messages %}
+		{% for message in messages %}
+			<div class="alert alert-{{ message.tags }} alert-dismissible" role="alert">
+			<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+				{{message}}
+			</div>
+		{% endfor %}
+	{% endif %}
+
+	<p>
+		Editing profile page of {{ request.user.username }}, More functionalities to be added
+		Please make sure to edit views. Currently it is not validating/ accepting form responses.
+	</p>
 	<form method="POST">
 		{% csrf_token %}
 		{{ form|crispy }}

--- a/cse_hub/users/views.py
+++ b/cse_hub/users/views.py
@@ -22,6 +22,9 @@ def profile_edit(request, username):
 	if username != request.user.username:
 		return HttpResponseRedirect(reverse('user-profile-edit', kwargs={'username':request.user.username}))
 		
+	# ===========Implement the followint logic ==================
+	# if request.method == 'POST':
+
 	context = {'form': ProfileUpdateForm()}
 	return render(request, 'users/profile_edit.html', context)
 	# return HttpResponse(f"Editing profile of {request.user.username}")


### PR DESCRIPTION
* After adding a problem, user is redirected to page that allows adding testcase (remember user can add testcases to only those problems which had been added by him/her)
* All pages that show django.messages now have a 'x' button to remove the notification without refreshing the page.