### PR TITLE
added built in editor (cdn supported)

### DIFF
--- a/cse_hub/cse_hub/settings.py
+++ b/cse_hub/cse_hub/settings.py
@@ -119,6 +119,9 @@ USE_L10N = True
 
 USE_TZ = True
 
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, "static"),
+]
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/

--- a/cse_hub/cse_hub/urls.py
+++ b/cse_hub/cse_hub/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from django.contrib.auth import views as auth_views
+from homepage.views import code_editor
 # from home import views
 
 urlpatterns = [
@@ -23,6 +24,7 @@ urlpatterns = [
     path('', include('homepage.urls')),
     path('profile/<str:username>/', include('users.urls')),
     path('problems/', include('problems.urls')),
+    path('editor/', code_editor, name='code-editor'),
     path('forum/', include('forum.urls')),
     path('login/', auth_views.LoginView.as_view(template_name='users/login.html'), name='user-login'),
     path('logout/', auth_views.LogoutView.as_view(template_name='users/logout.html'), name='user-logout'),

--- a/cse_hub/homepage/static/homepage/editor.css
+++ b/cse_hub/homepage/static/homepage/editor.css
@@ -1,0 +1,14 @@
+#editor { 
+/*    position: relative;
+    top: 60px;
+    right: 0;
+    bottom: 60px;
+    left: 0px;*/
+    width: 100%;
+    height: 750px;
+    display: inline-block;
+}
+
+#language {
+	padding-left: 25px;
+}

--- a/cse_hub/homepage/templates/homepage/editor.html
+++ b/cse_hub/homepage/templates/homepage/editor.html
@@ -1,0 +1,63 @@
+{% extends 'homepage/index.html' %}
+
+{% block content-unindent %}
+{% load static %}
+    <link rel="stylesheet" type="text/css" href="{% static 'homepage/editor.css' %}">
+
+    <div id="editor">Cook Your Code Here</div>
+
+    <div id="language" class="bg-dark text-white text-bold">
+        Language: &nbsp;
+        <label for="python"><input type="radio" name="language" id="python" value="python" checked="checked">Python</label> &nbsp;
+        <label for="cpp"><input type="radio" name="language" id="c_cpp" value="c_cpp">cpp</label>
+        <button class="float-right mr-3 btn btn-sm" id="copy">Copy</button>
+    </div>
+        
+   
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.5/ace.js" type="text/javascript" charset="utf-8"></script>
+    <script>
+        var lang = "python";
+        var editor;
+        function setEditor() {
+            editor = ace.edit("editor");
+            editor.setTheme("ace/theme/monokai");
+            // editor.session.setMode("ace/mode/python");
+            editor.session.setMode("ace/mode/" + lang);
+            document.getElementById('editor').style.fontSize='20px';
+        }
+
+        function copyToClipboard(text) {
+            var dummy = document.createElement("textarea");
+            // to avoid breaking orgain page when copying more words
+            // cant copy when adding below this code
+            // dummy.style.display = 'none'
+            document.body.appendChild(dummy);
+            //Be careful if you use texarea. setAttribute('value', value), which works with "input" does not work with "textarea". – Eduard
+            dummy.value = text;
+            dummy.select();
+            document.execCommand("copy");
+            document.body.removeChild(dummy);
+        }
+
+        setEditor();
+
+
+        $('#python').click(function () {
+            lang = 'python';
+            setEditor();
+        });
+
+        $('#c_cpp').click(function() {
+            lang = 'c_cpp';
+            setEditor();
+        });
+
+        $('#copy').click(function() {
+            copyToClipboard(editor.getValue());
+        });
+
+        
+    </script>
+
+{% endblock content-unindent %}

--- a/cse_hub/homepage/templates/homepage/index.html
+++ b/cse_hub/homepage/templates/homepage/index.html
@@ -85,14 +85,15 @@
 		</div>
 	</nav>
 
+	{% block content-unindent %}
+
+	{% endblock %}
+
 	<div class="container p-5">
 		{% block content %}
 
 		{% endblock %}
 	</div>
-		{% block content-unindent %}
-
-		{% endblock %}
 	<div class="container-fluid">
 		<div class="row">
 			<footer id="sticky-footer" class="py-4 bg-dark text-white-50" style="bottom: 0; position: fixed; width: 100%; color: #e05ea0;">

--- a/cse_hub/homepage/views.py
+++ b/cse_hub/homepage/views.py
@@ -27,3 +27,6 @@ def home(request):
         form = RegistrationForm()
     args = {'form':form}
     return render(request, 'homepage/homepage.html', args)
+
+def code_editor(request):
+    return render(request, 'homepage/editor.html')


### PR DESCRIPTION
closes #56 :tada: :smile: 
Note. It is code editor, not an Ide.

Supports: 
* Supports on click language change (see bootom left)
* code-folding
* Syntax highlighting as per language
* Multi cursor support (ctrl + leftMouseClick)
* Undo-redu, cut
* One click copy (see copy button on right bottom)
* Text selection highlight (select one text, highlights each instance of the text)

Required:
* Get a button to redirect to this page
* Work on UI (its width, height are made fixed, using css)
* Adding more features [Documentation](https://ace.c9.io/#nav=howto), Related [video](https://www.youtube.com/watch?v=GrHyIP0Ou8s) , More can be found easily
* currently using `cdn` requiring internet, remove cdn dependency
* Button to download file (good-first-issue)

Access:
* `http://127.0.0.1:8000/editor/`

ScreenShots:
![Screenshot from 2020-04-04 00-58-37](https://user-images.githubusercontent.com/46635452/78398589-f8909280-7610-11ea-96cf-63a4262eb855.png)

![Screenshot from 2020-04-04 00-51-00](https://user-images.githubusercontent.com/46635452/78398633-1100ad00-7611-11ea-98ce-60f2115b9ef5.png)
