### PR TITLE
Improved verdict evaluation speed

### DIFF
--- a/cse_hub/problems/evaluate.py
+++ b/cse_hub/problems/evaluate.py
@@ -2,8 +2,9 @@ import subprocess
 import os
 from django.conf import settings
 from problems.models import Problem, TestCase
+import multiprocessing
 
-def check(ques, sol, file, time):
+def check(ques, sol, file, time, result):
 	'''
 		Returns verdict of submitted code being ran on given testcase and corresponding solution
 	'''
@@ -20,6 +21,7 @@ def check(ques, sol, file, time):
 		for line in p.stderr.readlines():
 			# if we got compilation error, terminate
 			if line:
+				result['CE'] = 1
 				return 'CE'
 
 	# Just for refrence, prints the full command for file being checked to the terminal
@@ -29,6 +31,7 @@ def check(ques, sol, file, time):
 	try:
 		output, error = p.communicate(timeout=time)
 	except subprocess.TimeoutExpired:
+		result['TLE'] = 1
 		return 'TLE'
 
 	output = str(output, 'utf-8')
@@ -41,8 +44,10 @@ def check(ques, sol, file, time):
 	print(f'expected output is :- {exp_output}')
 
 	if output == exp_output:
+		result['AC'] = 1
 		return 'AC'
 
+	result['WA'] = 1
 	return 'WA'
 
 def evaluate(file, id):
@@ -52,12 +57,28 @@ def evaluate(file, id):
 	cur_problem = Problem.objects.get(id=id)
 	testcases = cur_problem.testcase_set.all()
 
+	processes = []
+	result = dict()
+
 	for test in testcases:
-		cur_verdict = check(str(test.testcase.path), str(test.solution.path), file, cur_problem.time)
+		p = multiprocessing.Process(target=check, args=(str(test.testcase.path), str(test.solution.path), file, cur_problem.time, result))
+		# cur_verdict = check(str(test.testcase.path), str(test.solution.path), file, cur_problem.time)
+		p.start()
+		processes.append(p)
+
+	for process in processes:
+		process.join()
+
+	if 'WA' in result.keys():
+		return 'WA'
+	elif 'TLE' in result.keys():
+		return 'TLE'
+	elif 'CE' in result.keys():
+		return 'CE'
 
 		# Just for reference
-		print(f'\n\n\nand returned verdict for current testcase is {cur_verdict}\n\n\n')
-		if cur_verdict != 'AC':
-			return cur_verdict
+		# print(f'\n\n\nand returned verdict for current testcase is {cur_verdict}\n\n\n')
+		# if cur_verdict != 'AC':
+		# 	return cur_verdict
 
 	return 'AC'

--- a/cse_hub/problems/forms.py
+++ b/cse_hub/problems/forms.py
@@ -1,10 +1,13 @@
-from django.forms import ModelForm
+from django.forms import ModelForm, FileInput
 from .models import Problem, TestCase, Submissions
 
 class SubmitSolutionForm(ModelForm):
 	class Meta:
 		model = Submissions
 		fields = ['submission_code']
+		widgets = {
+			'submission_code': FileInput(attrs={'accept': '.py,.cpp'}),
+		}
 
 class ProblemForm(ModelForm):
 	class Meta:
@@ -15,6 +18,10 @@ class TestCaseForm(ModelForm):
 	class Meta:
 		model = TestCase
 		fields = ['testcase', 'solution', 'question']
+		widgets = {
+			'testcase': FileInput(attrs={'accept': '.txt'}),
+			'solution': FileInput(attrs={'accept': '.txt'}),
+		}
 
 	def __init__(self, *args, **kwargs):
 		# for current user, display only those problems which he/she has added

--- a/cse_hub/problems/models.py
+++ b/cse_hub/problems/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.core.validators import FileExtensionValidator
 import datetime
 from django.contrib.auth.models import User
 from django.core.validators import FileExtensionValidator
@@ -62,8 +63,8 @@ class TestCase(models.Model):
 	'''
 	    Class for testcase of problems
 	'''
-	testcase = models.FileField(upload_to='problem_statements/testcases')
-	solution = models.FileField(upload_to='problem_statements/solutions')
+	testcase = models.FileField(upload_to='problem_statements/testcases', validators=[FileExtensionValidator(allowed_extensions=['txt'])])
+	solution = models.FileField(upload_to='problem_statements/solutions', validators=[FileExtensionValidator(allowed_extensions=['txt'])])
 
 	# if problem is deleted, delete this testcase as well
 	question = models.ForeignKey(Problem, on_delete=models.CASCADE)


### PR DESCRIPTION
closes #74 
In `evaluation.py`, instead of checking testcases in queue, used multiprocessing to evaluate testcases parallely. This is more useful when solution code roughly takes max_allowed time (but evaluates to AC), and there are many test cases. The evaluation process saw really great improvements. ! :smile: :tada: 

Added more layers of security, by allowing only specific types of file for upload,
1. For submissions: only `.py, .cpp`
2. For testcases and solutions: only `.txt`