### PR TITLE
now user can't access other's data while contest

### DIFF
--- a/cse_hub/cse_hub/settings.py
+++ b/cse_hub/cse_hub/settings.py
@@ -140,6 +140,9 @@ LOGIN_URL = '/login/'
 
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
+# Boolean value to tell if website is being used for contest
+CONTEST = True
+
 from django.contrib.messages import constants as messages
 MESSAGE_TAGS = {
     messages.ERROR: 'danger',

--- a/cse_hub/problems/views.py
+++ b/cse_hub/problems/views.py
@@ -10,15 +10,27 @@ import os
 from django.conf import settings
 from django.http import Http404, HttpResponse
 from .evaluate import evaluate
+from cse_hub.settings import CONTEST
 
 @login_required
 def submissions(request, username):
 	user = User.objects.get(username = username)
+
+	# if user is trying to access other's solutions while contest
+	if CONTEST and username != request.user.username:
+		messages.error(request, 'Not allowed while contest !')
+		return redirect(reverse('home'))
+
 	codes = submitted_codes.objects.filter(author = user)
 
 	return render(request, 'problems/display_submissions.html', {'codes':codes})
 
 def download_submission(request, id):
+	# if user is trying to access other's solutions while contest
+	if CONTEST and id != request.user.id:
+		messages.error(request, 'Not allowed while contest !')
+		return redirect(reverse('home'))
+
 	solution = submitted_codes.objects.get(id=id)
 	file_path = settings.BASE_DIR + solution.submission_code.url
 
@@ -30,6 +42,11 @@ def download_submission(request, id):
 	raise Http404
 
 def display_submission(request, username, id):
+	# if user is trying to access other's solutions while contest
+	if CONTEST and username != request.user.username:
+		messages.error(request, 'Not allowed while contest !')
+		return redirect(reverse('home'))
+
 	solution = submitted_codes.objects.get(id=id)
 	# file_path = os.path.join(settings.BASE_DIR,solution.submission_code.url)
 	file_path = settings.BASE_DIR + solution.submission_code.url


### PR DESCRIPTION
Closes #76 
Added `CONTEST` variable in `settings.py`, which denotes if a contest is active or not.
If A user tries to access other's codes during a contest, he/she is redirected to home page with a message about ongoing contest.

![Screenshot from 2020-04-20 17-06-59](https://user-images.githubusercontent.com/46635452/79747617-a0a09e00-8329-11ea-8590-83290fc3a3b1.png)
![Screenshot from 2020-04-20 17-07-10](https://user-images.githubusercontent.com/46635452/79747623-a26a6180-8329-11ea-9ce4-eac6429fab23.png)
